### PR TITLE
fix "do not boot" problem on 2.2.4

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -104,7 +104,7 @@ update-make-efi-iso-sh:
 depends.txt:
 	$(call colorecho, "get installed packages")
 	#docker run --rm tork/indigo bash -c 'echo "sudo apt-get update -qq; dpkg --get-selections | cut -d$$'"'"'\t'"'"' -f1 | xargs -r -n1 bash -c '"'"'apt-cache showpkg \$$0 | grep ubuntu.com > /dev/null && echo \$$0'"'"'" > gen_deps; bash ./gen_deps' | sed s/:amd64// | tee depends.txt
-	docker run --rm tork/indigo dpkg --get-selections | sed -e 's@\s*install$$@@g' | sed 's/:amd64//' | tee depends.txt
+	docker run --rm tork/indigo dpkg --get-selections | sed -e 's@\s*install$$@@g' | sed 's/:amd64//' | grep -v docker-engine | tee depends.txt
 
 tork-indigo.sh:
 	$(call colorecho, "get command history")

--- a/builder/make-efi-iso.sh
+++ b/builder/make-efi-iso.sh
@@ -20,9 +20,9 @@ sudo find . -type f -exec md5sum {} \; | grep -v isolinux | grep -v md5sum.txt |
 #sed -i 's@default vesamenu.c32@default live@' isolinux/isolinux.cfg
 sudo sed -i 's@^ui @#ui @' isolinux/isolinux.cfg
 # remove prompt to eject cd : http://www.pendrivelinux.com/ubuntu-remove-the-prompt-to-eject-cd/
-sudo sed -i 's@quiet splash --@quiet splash noprompt username=tork --@' isolinux/txt.cfg
+sudo sed -i 's@quiet\s\+splash\s\+--@quiet splash noprompt username=tork --@' isolinux/txt.cfg
 sudo sed -i 's@Ubuntu@ROS Ubuntu $(git describe --abbrev=0 --tags)@' isolinux/txt.cfg
-sudo sed -i 's@/casper/vmlinuz.efi file=/cdrom/preseed/ubuntu.seed boot=casper quiet splash --@/casper/vmlinuz.efi persistent file=/cdrom/preseed/ubuntu.seed boot=casper quiet splash noprompt username=tork --@' boot/grub/grub.cfg
+sudo sed -i 's@/casper/vmlinuz.efi\s\+file=/cdrom/preseed/ubuntu.seed\s\+boot=casper\s\+quiet\s\+splash\s\+--@/casper/vmlinuz.efi persistent file=/cdrom/preseed/ubuntu.seed boot=casper quiet splash noprompt username=tork --@' boot/grub/grub.cfg
 sudo sed -i 's@Ubuntu@ROS Ubuntu $(git describe --abbrev=0 --tags)@' boot/grub/grub.cfg
 # check for human
 cat isolinux/txt.cfg

--- a/builder/make-efi-iso.sh
+++ b/builder/make-efi-iso.sh
@@ -22,14 +22,15 @@ sudo sed -i 's@^ui @#ui @' isolinux/isolinux.cfg
 # remove prompt to eject cd : http://www.pendrivelinux.com/ubuntu-remove-the-prompt-to-eject-cd/
 sudo sed -i 's@quiet\s\+splash\s\+--@noprompt username=tork --@' isolinux/txt.cfg
 sudo sed -i 's@Ubuntu@ROS Ubuntu $(git describe --abbrev=0 --tags)@' isolinux/txt.cfg
-sudo sed -i 's@/casper/vmlinuz.efi\s\+file=/cdrom/preseed/ubuntu.seed\s\+boot=casper\s\+quiet\s\+splash\s\+--@/casper/vmlinuz.efi persistent file=/cdrom/preseed/ubuntu.seed boot=casper noprompt username=tork --@' boot/grub/grub.cfg
+#sudo sed -i 's@/casper/vmlinuz.efi\s\+file=/cdrom/preseed/ubuntu.seed\s\+boot=casper\s\+quiet\s\+splash\s\+--@/casper/vmlinuz.efi persistent file=/cdrom/preseed/ubuntu.seed boot=casper noprompt username=tork --@' boot/grub/grub.cfg
+sudo sed -i 's@/casper/vmlinuz.efi\s\+file=/cdrom/preseed/ubuntu.seed\s\+boot=casper\s\+quiet\s\+splash\s\+--@/casper/vmlinuz.efi persistent file=/cdrom/preseed/ubuntu.seed boot=casper noprompt --@' boot/grub/grub.cfg
 sudo sed -i 's@Ubuntu@ROS Ubuntu $(git describe --abbrev=0 --tags)@' boot/grub/grub.cfg
 # check for human
 cat isolinux/txt.cfg
 cat boot/grub/grub.cfg
 # check for computers
 grep tork isolinux/txt.cfg
-grep tork boot/grub/grub.cfg
+grep persistent boot/grub/grub.cfg
 
 cd ..
 cat <<EOF | sudo tee sort.txt

--- a/builder/make-efi-iso.sh
+++ b/builder/make-efi-iso.sh
@@ -24,8 +24,12 @@ sudo sed -i 's@quiet splash --@quiet splash noprompt username=tork --@' isolinux
 sudo sed -i 's@Ubuntu@ROS Ubuntu $(git describe --abbrev=0 --tags)@' isolinux/txt.cfg
 sudo sed -i 's@/casper/vmlinuz.efi file=/cdrom/preseed/ubuntu.seed boot=casper quiet splash --@/casper/vmlinuz.efi persistent file=/cdrom/preseed/ubuntu.seed boot=casper quiet splash noprompt username=tork --@' boot/grub/grub.cfg
 sudo sed -i 's@Ubuntu@ROS Ubuntu $(git describe --abbrev=0 --tags)@' boot/grub/grub.cfg
+# check for human
 cat isolinux/txt.cfg
 cat boot/grub/grub.cfg
+# check for computers
+grep tork isolinux/txt.cfg
+grep tork boot/grub/grub.cfg
 
 cd ..
 cat <<EOF | sudo tee sort.txt

--- a/builder/make-efi-iso.sh
+++ b/builder/make-efi-iso.sh
@@ -20,9 +20,9 @@ sudo find . -type f -exec md5sum {} \; | grep -v isolinux | grep -v md5sum.txt |
 #sed -i 's@default vesamenu.c32@default live@' isolinux/isolinux.cfg
 sudo sed -i 's@^ui @#ui @' isolinux/isolinux.cfg
 # remove prompt to eject cd : http://www.pendrivelinux.com/ubuntu-remove-the-prompt-to-eject-cd/
-sudo sed -i 's@quiet\s\+splash\s\+--@quiet splash noprompt username=tork --@' isolinux/txt.cfg
+sudo sed -i 's@quiet\s\+splash\s\+--@noprompt username=tork --@' isolinux/txt.cfg
 sudo sed -i 's@Ubuntu@ROS Ubuntu $(git describe --abbrev=0 --tags)@' isolinux/txt.cfg
-sudo sed -i 's@/casper/vmlinuz.efi\s\+file=/cdrom/preseed/ubuntu.seed\s\+boot=casper\s\+quiet\s\+splash\s\+--@/casper/vmlinuz.efi persistent file=/cdrom/preseed/ubuntu.seed boot=casper quiet splash noprompt username=tork --@' boot/grub/grub.cfg
+sudo sed -i 's@/casper/vmlinuz.efi\s\+file=/cdrom/preseed/ubuntu.seed\s\+boot=casper\s\+quiet\s\+splash\s\+--@/casper/vmlinuz.efi persistent file=/cdrom/preseed/ubuntu.seed boot=casper noprompt username=tork --@' boot/grub/grub.cfg
 sudo sed -i 's@Ubuntu@ROS Ubuntu $(git describe --abbrev=0 --tags)@' boot/grub/grub.cfg
 # check for human
 cat isolinux/txt.cfg

--- a/indigo/Dockerfile
+++ b/indigo/Dockerfile
@@ -31,8 +31,8 @@ set-option -g prefix C-t\n\
 
 ## gnomerc
 RUN echo "# Japnese settings\n\
-gsettings set org.gnome.desktop.input-sources sources [('xkb', 'jp') ('ibus', 'mozc-jp')]\n\
-gsettings set org.gnome.desktop.input-sourc xkb-options ['ctrl:swapcaps']\n\
+gsettings set org.gnome.desktop.input-sources sources \"[('xkb', 'jp') ('ibus', 'mozc-jp')]\"\n\
+gsettings set org.gnome.desktop.input-sourc xkb-options \"['ctrl:swapcaps']\"\n\
 " >  /etc/skel/.gnomerc
 
 ## .emacs

--- a/indigo/Dockerfile
+++ b/indigo/Dockerfile
@@ -31,8 +31,8 @@ set-option -g prefix C-t\n\
 
 ## gnomerc
 RUN echo "# Japnese settings\n\
-gsettings set org.gnome.desktop.input-sources sources \"[('xkb', 'jp') ('ibus', 'mozc-jp')]\"\n\
-gsettings set org.gnome.desktop.input-sourc xkb-options \"['ctrl:swapcaps']\"\n\
+gsettings set org.gnome.desktop.input-sources sources \"[('xkb', 'jp'), ('ibus', 'mozc-jp')]\"\n\
+gsettings set org.gnome.desktop.input-sources xkb-options \"['ctrl:swapcaps']\"\n\
 " >  /etc/skel/.gnomerc
 
 ## .emacs


### PR DESCRIPTION
- remove docker-engiine, which will be installed from https://get.docker.com/  scripts
- fix typo on gnomerc settings
- add " in gsettigs set org.gnome...
- builder/make-efi-iso.sh : remove quiet/splash
- there is two spaces between /casper/vmlinuz.efi and file=/cdroms...
- builder/make-efi-iso.sh : run grep to see if sed actually executed