### PR TITLE
fix problem reported from y.s. on jul/29

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -201,6 +201,12 @@ iso-build:
 	$(call colorecho, "cat tork-indigo.sh >> tork-defaults/hooks/chroot")
 	cat tork-indigo.sh >> tork-defaults/hooks/chroot
 
+	$(call colorecho, "use casper for vivid")
+	## work around for casper-rw partition http://askubuntu.com/a/725709/469233
+	echo "wget http://archive.ubuntu.com/ubuntu/pool/main/c/casper/casper_1.360_amd64.deb -O /tmp/casper_1.360_amd64.deb" >> tork-defaults/hooks/chroot
+	echo "sudo dpkg -x /tmp/casper_1.360_amd64.deb /tmp/casper-src" >> tork-defaults/hooks/chroot
+	echo "sudo cp /tmp/casper-src/usr/share/initramfs-tools/scripts/casper /usr/share/initramfs-tools/scripts/casper" >> tork-defaults/hooks/chroot
+
 	$(call colorecho, "cat depends.txt >> tork-defaults/depends.txt")
 	cat depends.txt >> tork-defaults/depends.txt
 

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -109,7 +109,7 @@ depends.txt:
 tork-indigo.sh:
 	$(call colorecho, "get command history")
 	# http://stackoverflow.com/questions/19104847/how-to-generate-a-dockerfile-from-an-image
-	docker history --no-trunc=true tork/indigo | tr -s " " | /bin/sed -e 's,#(nop) USER \[\(.*\)\],sudo -u \1 -H -i <<EOF,' | /bin/sed -e 's,#(nop) WORKDIR \(.*\),cd \1,' | /bin/sed -e 's,#(nop) ENV \(.*\),export \1,' | /bin/sed -n -e 's,[0-9.]* [kMG]\?B *$$,,p' | sed -n -e 's,.*/bin/sh -c \(.*\),\1,p' | /bin/sed -e 's,^\(.*\)#CIRCLECI#,#CIRCLECI# \1,' | tac | sed '0,/MAINTAINER/d' | tee tork-indigo.sh
+	docker history --no-trunc=true tork/indigo | tr -s " " | sed -e 's/$$ROS_DISTRO/indigo/' | /bin/sed -e 's,#(nop) USER \[\(.*\)\],sudo -u \1 -H -i <<"EOF",' | /bin/sed -e 's,#(nop) WORKDIR \(.*\),cd \1,' | /bin/sed -e 's,#(nop) ENV \(.*\),export \1,' | /bin/sed -n -e 's,[0-9.]* [kMG]\?B *$$,,p' | sed -n -e 's,.*/bin/sh -c \(.*\),\1,p' | /bin/sed -e 's,^\(.*\)#CIRCLECI#,#CIRCLECI# \1,' | tac | sed '0,/MAINTAINER/d' | tee tork-indigo.sh
 	echo "EOF" >> tork-indigo.sh
 
 tork-defaults:

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -139,8 +139,8 @@ tork-defaults:
 tork-defaults/debian/20_tork-defaults.gschema.override:
 	$(call colorecho, "setup 20_tork-defaults.gschema.override")
 	echo "[org.gnome.desktop.input-sources]" >> tork-defaults/debian/20_tork-defaults.gschema.override
-	$(call colorecho, "gsettings set org.gnome.desktop.input-sources xkb-options ['ctrl:swapcaps']")
-	echo "xkb-options=['ctrl:swapcaps']"  >> tork-defaults/debian/20_tork-defaults.gschema.override
+	$(call colorecho, "gsettings set org.gnome.desktop.input-sources xkb-options ['ctrl:nocaps']")
+	echo "xkb-options=['ctrl:nocaps']"  >> tork-defaults/debian/20_tork-defaults.gschema.override
 
 	$(call colorecho, 'gsettings set org.gnome.desktop.input-sources sources [("xkb", "jp") ("ibus", "mozc-jp")]')
 	#echo "sources=[('xkb', 'jp'), ('ibus', 'mozc-jp')]" >> tork-defaults/debian/20_tork-defaults.gschema.override

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -139,7 +139,7 @@ tork-defaults:
 tork-defaults/debian/20_tork-defaults.gschema.override:
 	$(call colorecho, "setup 20_tork-defaults.gschema.override")
 	echo "[org.gnome.desktop.input-sources]" >> tork-defaults/debian/20_tork-defaults.gschema.override
-	$(call colorecho, "gsettings set org.gnome.desktop.input-sourc xkb-options ['ctrl:swapcaps']")
+	$(call colorecho, "gsettings set org.gnome.desktop.input-sources xkb-options ['ctrl:swapcaps']")
 	echo "xkb-options=['ctrl:swapcaps']"  >> tork-defaults/debian/20_tork-defaults.gschema.override
 
 	$(call colorecho, 'gsettings set org.gnome.desktop.input-sources sources [("xkb", "jp") ("ibus", "mozc-jp")]')

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ dependencies:
          rm -f ~/docker/dockerfile.digest
       fi
     - if [ -e ~/docker/dockerfile.digest ]; then docker load --input ~/docker/tork-indigo.tar; fi
-    - if [ ! -e ~/docker/dockerfile.digest ]; then cd indigo; make all; fi
+    - cd indigo; make all
     - if [ ! -e ~/docker/dockerfile.digest ]; then docker save tork/indigo > ~/docker/tork-indigo.tar; fi
     - if [ ! -e ~/docker/dockerfile.digest ]; then md5sum indigo/Dockerfile  | cut -d' ' -f1 > ~/docker/dockerfile.digest; fi
     # setup vagrant

--- a/indigo/Dockerfile
+++ b/indigo/Dockerfile
@@ -143,7 +143,14 @@ RUN mkdir -p ~/Downloads
 RUN wget https://github.com/tork-a/ros_seminar/archive/1.0.1.tar.gz -O ~/Downloads/ros_seminar-1.0.1.tar.gz
 
 # settings
-RUN /bin/echo -e "\n\n# ROS setup\nsource /opt/ros/$ROS_DISTRO/setup.bash\n# This file is created on $(date) from live-cd @GIT_TAG@\n#" >> ~/.bashrc
+RUN echo "\n\n"\
+"# ROS setup\n"\
+"source /opt/ros/$ROS_DISTRO/setup.bash\n"\
+"source \`catkin locate --shell-verbs\` # shell support (https://catkin-tools.readthedocs.io/en/latest/advanced/catkin_shell_verbs.html)\n"\
+"\n\n"\
+"# This file is created on $(date) from live-cd @GIT_TAG@\n"\
+"#\n"\
+ >> ~/.bashrc
 ADD CHANGELOG.rst .
 RUN rosdep update || rosdep update
 


### PR DESCRIPTION
- builder/Makefile: use double quote for hiredocument to escape back quote command : http://stackoverflow.com/questions/13122147/prevent-expressions-enclosed-in-backticks-from-being-evaluated-in-heredocs
- builder/Makefile : fix caspser-rw partition workaround, see http://askubuntu.com/a/725709/469233
- circle.yml : always run docker build
- indigo/Dockerfile: support catkin shell-verbs
- build/Makefile: tork-defaults/debian/20_tork-defaults.gschema.override :  use nocaps instead of swapcaps, required from y.suzuki
- bulid/Makefile : tork-defaults/debian/20_tork-defaults.gschema.override :  fix typo : org.gnome.desktop.input-sour -> org.gnome.desktop.input-sources